### PR TITLE
Improve Usability

### DIFF
--- a/typespec-ts-mode.el
+++ b/typespec-ts-mode.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'treesit)
+(require 'c-ts-common)
 (eval-when-compile (require 'cl-lib))
 (eval-when-compile (require 'rx))
 
@@ -184,9 +185,7 @@
   (treesit-parser-create 'typespec)
 
   ;; Comments
-  (setq-local comment-start "//"
-              comment-end ""
-              comment-start-skip (rx "//" (* (syntax whitespace))))
+  (c-ts-common-comment-setup)
 
   ;; Font Lock
   (setq-local treesit-font-lock-feature-list typespec-ts-mode--font-lock-feature-list

--- a/typespec-ts-mode.el
+++ b/typespec-ts-mode.el
@@ -221,6 +221,16 @@ quotes, whichever is greater.
   (setq-local electric-indent-chars (append "{}" electric-indent-chars))
 
   ;; imenu
+  (setq-local treesit-defun-type-regexp (regexp-opt
+                                         '("alias_statement"
+                                           "const_statement"
+                                           "enum_statement"
+                                           "interface_statement"
+                                           "namespace_statement"
+                                           "operation_statement"
+                                           "scalar_statement"
+                                           "union_statement"
+                                           "model_statement")))
   (setq-local treesit-defun-name-function #'typespec-ts-mode--defun-name)
   (setq-local treesit-simple-imenu-settings
               `(("Alias" "\\`alias_statement\\'")

--- a/typespec-ts-mode.el
+++ b/typespec-ts-mode.el
@@ -144,6 +144,21 @@
   :safe 'integerp
   :group 'typespec)
 
+(defvar typespec-ts-mode--syntax-table
+  (let ((table (make-syntax-table)))
+    (modify-syntax-entry ?_ "_" table)
+    (modify-syntax-entry ?= "." table)
+    (modify-syntax-entry ?& "." table)
+    (modify-syntax-entry ?| "." table)
+    (modify-syntax-entry ?` "\"" table)
+    ;; comments like c-mode(s)
+    (modify-syntax-entry ?/ ". 124b" table)
+    (modify-syntax-entry ?* ". 23" table)
+    (modify-syntax-entry ?\n "> b" table)
+    (modify-syntax-entry ?\^m "> b" table)
+    table)
+  "Syntax table for `typespec-ts-mode'.")
+
 (defvar typespec-ts-mode--indent-rules
   '((typespec
      ((parent-is "source_file") parent 0)
@@ -161,6 +176,7 @@
 (define-derived-mode typespec-ts-mode prog-mode "TypeSpec"
   "Major mode for editing TypeSpec files."
   :group 'typespec
+  :syntax-table typespec-ts-mode--syntax-table
 
   (unless (treesit-available-p)
     (error "Tree-sitter is not available"))

--- a/typespec-ts-mode.el
+++ b/typespec-ts-mode.el
@@ -98,7 +98,7 @@
    :feature 'keyword
    ;; https://github.com/microsoft/typespec/blob/main/packages/spec/src/spec.emu.html#L34
    '(["import" "model" "namespace" "op" "extends" "using" "interface" "union"
-      "dec" "fn" "void" "never" "unknown" "alias" "enum" "scalar" "is"
+      "dec" "fn" "void" "never" "unknown" "alias" "enum" "scalar" "is" "const"
       (decorator_modifiers) (function_modifiers)] @font-lock-keyword-face)
 
    :language 'typespec


### PR DESCRIPTION
This patch series improves the usability around indentation and `thing-at-point`. The main motivation was to fix the wrong indentation when inserting a new line. The fixes adapt similar settings as the already existing modes (e.g. typescript-ts-mode). While fixing these issue, I also found additional things which improves the usability of this mode.

Each commit includes details about the changes. I tried to commit this to be as self-contained as possible. If you have any questions feel free to ask.